### PR TITLE
fix evaluate python code in remote directory

### DIFF
--- a/lisp/ob-python.el
+++ b/lisp/ob-python.el
@@ -345,7 +345,8 @@ last statement in BODY, as elisp."
 					      "python-")))
 			   (with-temp-file tmp-src-file (insert body))
 			   (format org-babel-python--eval-ast
-				   tmp-src-file))))
+				   (file-local-name
+				    tmp-src-file)))))
                (org-babel-comint-with-output
                    (session org-babel-python-eoe-indicator nil body)
                  (let ((comint-process-echoes nil))


### PR DESCRIPTION
Evaluating an "AST python code" should be local to the process /
directory.

`file-local-name` will do just this (strip the tramp prefix in path)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bzg/org-mode/2)
<!-- Reviewable:end -->
