### PR TITLE
Allow spacial characters in :dbpassword with postgresql

### DIFF
--- a/lisp/ob-sql.el
+++ b/lisp/ob-sql.el
@@ -282,7 +282,7 @@ This function is called by `org-babel-execute-src-block'."
 					    "%s%s --set=\"ON_ERROR_STOP=1\" %s -A -P \
 footer=off -F \"\t\"  %s -f %s -o %s %s"
 					    (if dbpassword
-						(format "PGPASSWORD=%s " dbpassword)
+						(format "PGPASSWORD=\"%s\" " dbpassword)
 					      "")
                                             (or (bound-and-true-p
                                                  sql-postgres-program)


### PR DESCRIPTION
dbpassword is passed to sql as envvar. The password should be quoted to allow for special characters or spaces in the password string.